### PR TITLE
バージョン番号を確認するワークフローの追加

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,23 @@
+﻿name: Check PR for specific file changes
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Check for file changes
+        run: |
+          if ! git diff --name-only origin/main | grep -q "TextWrapper.cs"; then
+          # 現在のブランチとリモートの main ブランチとの差分を確認。ファイル名 "TextWrapper.cs" が含まれるか調べる。
+
+          echo "TextWrapper.cs has not been changed. Rejecting PR."
+          exit 1  # 指定したファイル名が含まれない場合、エラーのコード (1) を返す
+          else
+          echo "TextWrapper.cs has been changed. Proceeding with PR."
+          fi

--- a/FileOrganizer3/Models/TextWrapper.cs
+++ b/FileOrganizer3/Models/TextWrapper.cs
@@ -34,7 +34,7 @@ namespace FileOrganizer3.Models
         [Conditional("RELEASE")]
         private void SetVersion()
         {
-            Version = "20240916" + "b";
+            Version = "20240917" + "a";
         }
 
         [Conditional("DEBUG")]


### PR DESCRIPTION
プルリクエストのマージの際、バージョン番号の確認（実際には TextWrapper の変更の有無）を確認するワークフローを追加しました。