### PR TITLE
リストからファイルをコピーする機能の追加

### DIFF
--- a/FileOrganizer3/App.xaml
+++ b/FileOrganizer3/App.xaml
@@ -3,9 +3,11 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="clr-namespace:FileOrganizer3.Views.Converters"
-    xmlns:prism="http://prismlibrary.com/">
+    xmlns:prism="http://prismlibrary.com/"
+    xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <Application.Resources>
         <SolidColorBrush x:Key="BgColorBrush" Color="DimGray" />
         <converters:ZeroPaddingConverter x:Key="ZeroPaddingConverter" />
+        <sys:Double x:Key="BasicFontSize">15</sys:Double>
     </Application.Resources>
 </prism:PrismApplication>

--- a/FileOrganizer3/App.xaml.cs
+++ b/FileOrganizer3/App.xaml.cs
@@ -19,6 +19,7 @@ namespace FileOrganizer3
         {
             containerRegistry.RegisterDialog<SettingPage, SettingPageViewModel>();
             containerRegistry.RegisterDialog<InputPage, InputPageViewModel>();
+            containerRegistry.RegisterDialog<FileCopyPage, FileCopyPageViewModel>();
         }
     }
 }

--- a/FileOrganizer3/Models/FileInfoWrapper.cs
+++ b/FileOrganizer3/Models/FileInfoWrapper.cs
@@ -96,5 +96,10 @@ namespace FileOrganizer3.Models
             RaisePropertyChanged(nameof(IsSoundFile));
             RaisePropertyChanged(nameof(Extension));
         }
+
+        public void CopyTo(string destinationPath)
+        {
+            FileInfo.CopyTo(destinationPath);
+        }
     }
 }

--- a/FileOrganizer3/Models/FileInfoWrapper.cs
+++ b/FileOrganizer3/Models/FileInfoWrapper.cs
@@ -99,7 +99,7 @@ namespace FileOrganizer3.Models
 
         public void CopyTo(string destinationPath)
         {
-            FileInfo.CopyTo(destinationPath);
+            FileInfo.CopyTo($"{destinationPath}\\{FileInfo.Name}");
         }
     }
 }

--- a/FileOrganizer3/Models/TextWrapper.cs
+++ b/FileOrganizer3/Models/TextWrapper.cs
@@ -34,7 +34,7 @@ namespace FileOrganizer3.Models
         [Conditional("RELEASE")]
         private void SetVersion()
         {
-            Version = "20241208" + "a";
+            Version = "20241213" + "a";
         }
 
         [Conditional("DEBUG")]

--- a/FileOrganizer3/ViewModels/DesignTimeViewModel.cs
+++ b/FileOrganizer3/ViewModels/DesignTimeViewModel.cs
@@ -44,5 +44,7 @@ namespace FileOrganizer3.ViewModels
         });
 
         public DelegateCommand ShowSettingPageCommand { get; } = new (() => { });
-}
+
+        public DelegateCommand ShowFileCopyPageCommand { get; } = new (() => { });
+    }
 }

--- a/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
+++ b/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Prism.Commands;
+using Prism.Mvvm;
+using Prism.Services.Dialogs;
+
+namespace FileOrganizer3.ViewModels
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class FileCopyPageViewModel : BindableBase, IDialogAware
+    {
+        public event Action<IDialogResult> RequestClose;
+
+        public string Title => "File Copy Page";
+
+        public DelegateCommand CloseCommand => new DelegateCommand(() =>
+        {
+            RequestClose?.Invoke(new DialogResult());
+        });
+
+        public bool CanCloseDialog() => true;
+
+        public void OnDialogClosed()
+        {
+        }
+
+        public void OnDialogOpened(IDialogParameters parameters)
+        {
+        }
+    }
+}

--- a/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
+++ b/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using FileOrganizer3.Models;
 using Prism.Commands;
@@ -38,6 +39,13 @@ namespace FileOrganizer3.ViewModels
 
         public DelegateCommand CopyFilesCommand => new DelegateCommand(() =>
         {
+            if (string.IsNullOrWhiteSpace(FileListText) || FileInfoWrappers == null || FileInfoWrappers.Count == 0 || !Directory.Exists(FileDestinationPath))
+            {
+                return;
+            }
+
+            var lines = FileListText.Split(new[] { "\r\n", "\n", "\r", }, StringSplitOptions.RemoveEmptyEntries);
+            CopyFiles(lines, FileInfoWrappers, FileDestinationPath);
         });
 
         public bool CanCloseDialog() => true;
@@ -48,6 +56,10 @@ namespace FileOrganizer3.ViewModels
 
         public void OnDialogOpened(IDialogParameters parameters)
         {
+            if (parameters.TryGetValue<List<FileInfoWrapper>>(nameof(FileContainer.FileInfoWrappers), out var fw))
+            {
+                FileInfoWrappers = fw;
+            }
         }
 
         /// <summary>

--- a/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
+++ b/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using FileOrganizer3.Models;
 using Prism.Commands;
 using Prism.Mvvm;
 using Prism.Services.Dialogs;
@@ -8,13 +10,33 @@ namespace FileOrganizer3.ViewModels
     // ReSharper disable once ClassNeverInstantiated.Global
     public class FileCopyPageViewModel : BindableBase, IDialogAware
     {
+        private string fileListText;
+        private string logText;
+        private string fileDestinationPath;
+
         public event Action<IDialogResult> RequestClose;
 
         public string Title => "File Copy Page";
 
+        public string FileListText { get => fileListText; set => SetProperty(ref fileListText, value); }
+
+        public string LogText { get => logText; set => SetProperty(ref logText, value); }
+
+        public List<FileInfoWrapper> FileInfoWrappers { get; set; }
+
+        public string FileDestinationPath
+        {
+            get => fileDestinationPath;
+            set => SetProperty(ref fileDestinationPath, value);
+        }
+
         public DelegateCommand CloseCommand => new DelegateCommand(() =>
         {
             RequestClose?.Invoke(new DialogResult());
+        });
+
+        public DelegateCommand CopyFilesCommand => new DelegateCommand(() =>
+        {
         });
 
         public bool CanCloseDialog() => true;

--- a/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
+++ b/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
@@ -22,9 +22,7 @@ namespace FileOrganizer3.ViewModels
 
         public string FileListText { get => fileListText; set => SetProperty(ref fileListText, value); }
 
-        public string LogText { get => logText; set => SetProperty(ref logText, value); }
-
-        public List<FileInfoWrapper> FileInfoWrappers { get; set; }
+        public string LogText { get => logText; private set => SetProperty(ref logText, value); }
 
         public string FileDestinationPath
         {
@@ -47,6 +45,8 @@ namespace FileOrganizer3.ViewModels
             var lines = FileListText.Split(new[] { "\r\n", "\n", "\r", }, StringSplitOptions.RemoveEmptyEntries);
             CopyFiles(lines, FileInfoWrappers, FileDestinationPath);
         });
+
+        private List<FileInfoWrapper> FileInfoWrappers { get; set; }
 
         public bool CanCloseDialog() => true;
 

--- a/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
+++ b/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
@@ -63,7 +63,8 @@ namespace FileOrganizer3.ViewModels
         }
 
         /// <summary>
-        /// fileNames の名前を、sourceFileInfos の中から検索して destinationPath にコピーします。
+        /// fileNames の名前を、sourceFileInfos の中から検索して destinationPath にコピーします。<br/>
+        /// また、必要に応じて LogText プロパティにログを出力します。
         /// </summary>
         /// <param name="fileNames">コピーの対象とするファイル名</param>
         /// <param name="sourceFileInfos">コピーの対象を含む FileInfo のリスト</param>
@@ -78,6 +79,10 @@ namespace FileOrganizer3.ViewModels
                 if (fileInfos.TryGetValue(fileName, out var fileInfoWrapper))
                 {
                     fileInfoWrapper.CopyTo(destinationPath);
+                }
+                else
+                {
+                    LogText += $"{fileName} がソースファイルリストに含まれていないため、コピーできませんでした。\n";
                 }
             }
         }

--- a/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
+++ b/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using FileOrganizer3.Models;
 using Prism.Commands;
 using Prism.Mvvm;
@@ -47,6 +48,26 @@ namespace FileOrganizer3.ViewModels
 
         public void OnDialogOpened(IDialogParameters parameters)
         {
+        }
+
+        /// <summary>
+        /// fileNames の名前を、sourceFileInfos の中から検索して destinationPath にコピーします。
+        /// </summary>
+        /// <param name="fileNames">コピーの対象とするファイル名</param>
+        /// <param name="sourceFileInfos">コピーの対象を含む FileInfo のリスト</param>
+        /// <param name="destinationPath">コピー先のパス</param>
+        private void CopyFiles(IEnumerable<string> fileNames, IEnumerable<FileInfoWrapper> sourceFileInfos, string destinationPath)
+        {
+            // ファイル名がユニークでない場合はエラーが出る？
+            var fileInfos = sourceFileInfos.ToDictionary(f => f.Name);
+
+            foreach (var fileName in fileNames)
+            {
+                if (fileInfos.TryGetValue(fileName, out var fileInfoWrapper))
+                {
+                    fileInfoWrapper.CopyTo(destinationPath);
+                }
+            }
         }
     }
 }

--- a/FileOrganizer3/ViewModels/IMainWindowViewModel.cs
+++ b/FileOrganizer3/ViewModels/IMainWindowViewModel.cs
@@ -24,5 +24,7 @@ namespace FileOrganizer3.ViewModels
         DelegateCommand StopSoundCommand { get; }
 
         DelegateCommand ShowSettingPageCommand { get; }
+
+        DelegateCommand ShowFileCopyPageCommand { get; }
     }
 }

--- a/FileOrganizer3/ViewModels/MainWindowViewModel.cs
+++ b/FileOrganizer3/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 using FileOrganizer3.Models;
 using FileOrganizer3.Views;
 using Prism.Commands;
@@ -86,6 +87,16 @@ namespace FileOrganizer3.ViewModels
         public DelegateCommand ShowSettingPageCommand => new DelegateCommand(() =>
         {
             dialogService.ShowDialog(nameof(SettingPage), new DialogParameters(), (_) => { });
+        });
+
+        public DelegateCommand ShowFileCopyPageCommand => new DelegateCommand(() =>
+        {
+            var param = new DialogParameters
+            {
+                { nameof(FileContainer.FileInfoWrappers), FileContainer.FileInfoWrappers.ToList() },
+            };
+
+            dialogService.ShowDialog(nameof(FileCopyPage), param, (_) => { });
         });
 
         public void Dispose()

--- a/FileOrganizer3/Views/FileCopyPage.xaml
+++ b/FileOrganizer3/Views/FileCopyPage.xaml
@@ -24,7 +24,10 @@
                 DockPanel.Dock="Top"
                 FontSize="{StaticResource BasicFontSize}"
                 Text="コピーするファイルを入力してください :" />
-            <TextBox FontSize="{StaticResource BasicFontSize}" Text="{Binding FileListText, UpdateSourceTrigger=PropertyChanged}" />
+            <TextBox
+                AcceptsReturn="True"
+                FontSize="{StaticResource BasicFontSize}"
+                Text="{Binding FileListText, UpdateSourceTrigger=PropertyChanged}" />
         </DockPanel>
 
         <DockPanel Grid.Row="1" Margin="0,10">

--- a/FileOrganizer3/Views/FileCopyPage.xaml
+++ b/FileOrganizer3/Views/FileCopyPage.xaml
@@ -6,9 +6,55 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="clr-namespace:FileOrganizer3.ViewModels"
     Title="FileCopyPage"
-    Width="800"
-    Height="450"
+    Width="600"
+    Height="400"
     d:DataContext="{d:DesignInstance viewModels:FileCopyPageViewModel}"
     mc:Ignorable="d">
-    <Grid />
+    <Grid Margin="4">
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <DockPanel Grid.Row="0">
+            <TextBlock
+                Margin="0,2"
+                DockPanel.Dock="Top"
+                FontSize="{StaticResource BasicFontSize}"
+                Text="コピーするファイルを入力してください :" />
+            <TextBox FontSize="{StaticResource BasicFontSize}" />
+        </DockPanel>
+
+        <DockPanel Grid.Row="1" Margin="0,10">
+            <TextBlock
+                Margin="0,2"
+                DockPanel.Dock="Top"
+                FontSize="{StaticResource BasicFontSize}"
+                Text="コピー先を入力してください :" />
+            <TextBox FontSize="{StaticResource BasicFontSize}" />
+        </DockPanel>
+
+        <StackPanel
+            Grid.Row="2"
+            HorizontalAlignment="Right"
+            Orientation="Horizontal">
+            <Button Margin="5,0" Padding="20,1">
+                <TextBlock FontSize="{StaticResource BasicFontSize}" Text="Copy" />
+            </Button>
+            <Button Margin="10,0" Padding="10,1">
+                <TextBlock FontSize="{StaticResource BasicFontSize}" Text="Close" />
+            </Button>
+        </StackPanel>
+
+        <DockPanel Grid.Row="3" Margin="0,10">
+            <TextBlock
+                Margin="0,2"
+                DockPanel.Dock="Top"
+                FontSize="{StaticResource BasicFontSize}"
+                Text="ログ :" />
+            <TextBlock FontSize="{StaticResource BasicFontSize}" />
+        </DockPanel>
+    </Grid>
 </Page>

--- a/FileOrganizer3/Views/FileCopyPage.xaml
+++ b/FileOrganizer3/Views/FileCopyPage.xaml
@@ -24,7 +24,7 @@
                 DockPanel.Dock="Top"
                 FontSize="{StaticResource BasicFontSize}"
                 Text="コピーするファイルを入力してください :" />
-            <TextBox FontSize="{StaticResource BasicFontSize}" />
+            <TextBox FontSize="{StaticResource BasicFontSize}" Text="{Binding FileListText, UpdateSourceTrigger=PropertyChanged}" />
         </DockPanel>
 
         <DockPanel Grid.Row="1" Margin="0,10">
@@ -33,17 +33,23 @@
                 DockPanel.Dock="Top"
                 FontSize="{StaticResource BasicFontSize}"
                 Text="コピー先を入力してください :" />
-            <TextBox FontSize="{StaticResource BasicFontSize}" />
+            <TextBox FontSize="{StaticResource BasicFontSize}" Text="{Binding FileDestinationPath, UpdateSourceTrigger=PropertyChanged}" />
         </DockPanel>
 
         <StackPanel
             Grid.Row="2"
             HorizontalAlignment="Right"
             Orientation="Horizontal">
-            <Button Margin="5,0" Padding="20,1">
+            <Button
+                Margin="5,0"
+                Padding="20,1"
+                Command="{Binding CopyFilesCommand}">
                 <TextBlock FontSize="{StaticResource BasicFontSize}" Text="Copy" />
             </Button>
-            <Button Margin="10,0" Padding="10,1">
+            <Button
+                Margin="10,0"
+                Padding="10,1"
+                Command="{Binding CloseCommand}">
                 <TextBlock FontSize="{StaticResource BasicFontSize}" Text="Close" />
             </Button>
         </StackPanel>
@@ -54,7 +60,7 @@
                 DockPanel.Dock="Top"
                 FontSize="{StaticResource BasicFontSize}"
                 Text="ログ :" />
-            <TextBlock FontSize="{StaticResource BasicFontSize}" />
+            <TextBlock FontSize="{StaticResource BasicFontSize}" Text="{Binding LogText}" />
         </DockPanel>
     </Grid>
 </Page>

--- a/FileOrganizer3/Views/FileCopyPage.xaml
+++ b/FileOrganizer3/Views/FileCopyPage.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="FileOrganizer3.Views.FileCopyPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModels="clr-namespace:FileOrganizer3.ViewModels"
+    Title="FileCopyPage"
+    Width="800"
+    Height="450"
+    d:DataContext="{d:DesignInstance viewModels:FileCopyPageViewModel}"
+    mc:Ignorable="d">
+    <Grid />
+</Page>

--- a/FileOrganizer3/Views/FileCopyPage.xaml.cs
+++ b/FileOrganizer3/Views/FileCopyPage.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace FileOrganizer3.Views
+{
+    public partial class FileCopyPage
+    {
+        public FileCopyPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/FileOrganizer3/Views/MainWindow.xaml
+++ b/FileOrganizer3/Views/MainWindow.xaml
@@ -56,6 +56,8 @@
 
                     <MenuItem Command="{Binding FileContainer.SearchCommand}" Header="入力中の検索ワードで再検索 (F)" />
 
+                    <MenuItem Command="{Binding ShowFileCopyPageCommand}" Header="ファイルコピーダイアログを表示" />
+
                 </MenuItem>
 
                 <MenuItem Header="マーク">


### PR DESCRIPTION
ファイル名のリストで対象を指定し、もう一方のソースリストにマッチするファイルがあればコピーを実行する機能を実装しました。