### PR TITLE
機能拡張 / ファイルコピー時のファイル名比較でケースを無視

### DIFF
--- a/FileOrganizer3/Models/TextWrapper.cs
+++ b/FileOrganizer3/Models/TextWrapper.cs
@@ -34,7 +34,7 @@ namespace FileOrganizer3.Models
         [Conditional("RELEASE")]
         private void SetVersion()
         {
-            Version = "20241214" + "a";
+            Version = "20241215" + "a";
         }
 
         [Conditional("DEBUG")]

--- a/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
+++ b/FileOrganizer3/ViewModels/FileCopyPageViewModel.cs
@@ -90,11 +90,12 @@ namespace FileOrganizer3.ViewModels
         private void CopyFiles(IEnumerable<string> fileNames, IEnumerable<FileInfoWrapper> sourceFileInfos, string destinationPath)
         {
             // ファイル名がユニークでない場合はエラーが出る？
-            var fileInfos = sourceFileInfos.ToDictionary(f => f.Name);
+            var fileInfos = sourceFileInfos.ToDictionary(f => f.Name.ToLower());
 
             foreach (var fileName in fileNames)
             {
-                if (fileInfos.TryGetValue(fileName, out var fileInfoWrapper))
+                var n = fileName.ToLower();
+                if (fileInfos.TryGetValue(n, out var fileInfoWrapper))
                 {
                     fileInfoWrapper.CopyTo(destinationPath);
                 }


### PR DESCRIPTION
ディクショナリーのキーと、ファイルリストの文字列を一旦小文字に変換することで実装した。
この変更により、大文字と小文字が混在するようなファイル名であっても対処でき、使い勝手が向上する。