### PR TITLE
リリース / 20250430a

### DIFF
--- a/FileOrganizer3/Behaviors/ListBoxKeyDownBehavior.cs
+++ b/FileOrganizer3/Behaviors/ListBoxKeyDownBehavior.cs
@@ -247,6 +247,11 @@ namespace FileOrganizer3.Behaviors
                 return;
             }
 
+            if (listBox.SelectedIndex < 0)
+            {
+                return;
+            }
+
             var item = listBox.Items[listBox.SelectedIndex];
 
             if (item == null)

--- a/FileOrganizer3/Models/TextWrapper.cs
+++ b/FileOrganizer3/Models/TextWrapper.cs
@@ -34,7 +34,7 @@ namespace FileOrganizer3.Models
         [Conditional("RELEASE")]
         private void SetVersion()
         {
-            Version = "20241218" + "a";
+            Version = "20250430" + "a";
         }
 
         [Conditional("DEBUG")]


### PR DESCRIPTION
- 修正
    - Shift + J, Shift + K の押下でアプリがクラッシュする不具合を修正。
        - 原因は、OnSelectionChanged の中で、負のインデックスを参照してしまうことだった。